### PR TITLE
Correctly route arguments to TimedRotatingFileHandler's constructor.

### DIFF
--- a/wsgilog/__init__.py
+++ b/wsgilog/__init__.py
@@ -37,7 +37,8 @@ __all__ = ['WsgiLog', 'log']
 
 # File rotation constants
 BACKUPS = 1
-INTERVAL = 'h'
+INTERVAL = 1
+WHEN = 'h'
 # Default logger name (should be changed)
 LOGNAME = 'wsgilog.log'
 # Default 'environ' entries
@@ -122,10 +123,11 @@ class WsgiLog(object):
                 setlog(TimedRotatingFileHandler(
                     # Log file path
                     kw.get('file', LOGNAME),
+                    when=kw.get('when', WHEN),
                     # Interval to backup log file
-                    kw.get('interval', INTERVAL),
+                    interval=kw.get('interval', INTERVAL),
                     # Number of backups to keep
-                    kw.get('backups', BACKUPS)))
+                    backupCount=kw.get('backups', BACKUPS)))
             # Send log entries to an email address
             if 'toemail' in kw:
                 setlog(SMTPHandler(


### PR DESCRIPTION
Previously, WsgiLog passed its backups argument to TimedRotatingFileHandler's interval argument,
while it passed its interval argument to TimedRotatingFileHandler's when argument. Passing the
arguments like this incorrectly multiplies the interval by the number of requested backups. Thus,
a request for daily backups with 7 backup files actually keeps one backup file for 7 days. Furthermore,
passing 0 for backups, which is expected to work with TimedRotatingFileHandler's notion of backups,
causes logging to hang (at least in our environment).

This pull request creates a when argument and adapts the interval argument so they match
TimedRotatingFileHandler's expectations.